### PR TITLE
Reuse buffer if it already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ let g:noteworthy_vsplit_size = 80
 #### Create or edit a note
 Create or edit a note with `:Note SUBJECT...`. The `SUBJECT` will be used as
 the file name, and any spaces will be replaced by underscores. No file extension
-is required.
+is required. If a buffer with that note already exists, it will be reused. If
+it's already open in a window, focus will change to that window.
 
 ```
 :Note I need to remember this

--- a/autoload/noteworthy.vim
+++ b/autoload/noteworthy.vim
@@ -55,7 +55,7 @@ function! noteworthy#Open(command, file, range, line1, line2) abort
     endif
   endif
   if !isdirectory(l:basedir) | call mkdir(l:basedir, 'p') | endif
-  execute get(s:app, a:command . '_size', '') . a:command l:file
+  call s:OpenFile(l:file, a:command)
   if s:app.use_header && getfsize(l:file) <= 0
     let l:title = substitute(fnamemodify(l:file, ':t:r'), s:app.delimiter, ' ', 'g')
     let l:func = exists('*NoteworthyHeader') ? 'NoteworthyHeader' : 's:Header'
@@ -176,6 +176,15 @@ function! s:HandleDynamicLibraries() abort
   endif
 endfunction
 
+function! s:OpenFile(filename, command) abort
+  if !bufexists(a:filename) || a:command =~# 'split'
+    execute get(s:app, a:command . '_size', '') . a:command a:filename
+    return
+  endif
+  let l:win_num = bufwinnr(a:filename)
+  execute l:win_num == -1 ? 'buffer ' . bufnr(a:filename) : l:win_num . 'wincmd w'
+endfunction
+
 function! s:GetFileName(file, delim, directory) abort dict
   let l:segments = split(a:file)
   let l:dir = s:app.current_directory()
@@ -192,10 +201,6 @@ endfunction
 
 function! s:Header(title, file) abort
   return '# ' . substitute(a:title, '\<.', '\u&', 'g')
-endfunction
-
-function s:Deprecated(from, to) abort
-  call s:Warn(a:from . ' is deprecated. Use ' . a:to . 'instead.')
 endfunction
 
 function! s:Warn(message) abort

--- a/doc/noteworthy.txt
+++ b/doc/noteworthy.txt
@@ -233,22 +233,29 @@ COMMANDS                                                   *noteworthy-commands*
 :[{range}]Note {topic} [{, ...}]
                             Create new {topic} markdown file in the
                             |b:noteworthy_current_library|, or open it if it
-                            already exists. The file extension can be omitted.
-                            Can be multiple words separated by spaces, which
-                            will be replaced by underscores in the file name.
-                            If [{range}] is provided (works with visual
-                            selection), the lines of the current file will be
-                            appended to the note. By default, the copied text
-                            will be wrapped in a markdown code block. To
-                            disable this, see |g:noteworthy_use_code_block|.
+                            already exists. If a buffer with that note already
+                            exists, it will be reused. If it's already open in
+                            a window, focus will change to that window.The file
+                            extension can be omitted.  Can be multiple words
+                            separated by spaces, which will be replaced by
+                            underscores in the file name.  If [{range}] is
+                            provided (works with visual selection), the lines
+                            of the current file will be appended to the note.
+                            By default, the copied text will be wrapped in a
+                            markdown code block. To disable this, see
+                            |g:noteworthy_use_code_block|.
 
                                                                         *:Snote*
 :[{range}]Snote {topic} [{, ...}]
-                            Same as |:Note|, but opens in a split.
+                            Same as |:Note|, but opens in a split. The only
+                            difference is, if the note is already open in a
+                            window, the buffer will still be reused, but it
+                            will be opened in a new split window. Use |:Note|
+                            if you want to switch to the open window.
 
                                                                         *:Vnote*
 :[{range}]Vnote {topic} [{, ...}]
-                            Same as |:Note|, but opens in a vertical split.
+                            Same as |:Snote|, but opens in a vertical split.
 
                                                                         *:Tnote*
 :[{range}]Tnote {topic} [{, ...}]


### PR DESCRIPTION
- `:Note` will now reuse a buffer it it already exists
  - It will also switch windows if the buffer is already open in a window
- `:Snote` and `:Vnote`, as of now, will always create a new split
  - Buffers will be reused, but windows will not
  - Subject to change, but I think if you specify a split, it should always split
- Updated documentation and readme